### PR TITLE
Pic in article-edit disappeared-after-editing fix

### DIFF
--- a/js/page-main.js
+++ b/js/page-main.js
@@ -74,8 +74,8 @@ jQuery(function($) {
         afterClose	:	function( ) {
             $('#arlima-article-image-container')
                 .removeClass('arlima-fancybox media-item-info')
-                .addClass('media-item-info');
-
+                .addClass('media-item-info')
+				.removeAttr("style");
             $('#arlima-article-image img').removeClass('thumbnail');
             $('#arlima-article-image-scissors').html('').hide();
             Arlima.ArticleEditor.updateArticleImage({updated : Math.round(new Date().getTime() / 1000)});


### PR DESCRIPTION
Click edit on article-image, edit the image then close the fancybox. The pic vanishes.

The pic shows up again until you click the article once again, removed the style attribute that held the "display-none" tag for the fancybox movement.
