### PR TITLE
Suggested solution for supporting custom labels on file includes

### DIFF
--- a/pages/main.php
+++ b/pages/main.php
@@ -369,8 +369,8 @@ $arlima_plugin = new Arlima_Plugin();
         </div><!-- #arlima-custom-templates -->
 
         <?php
-        $file_includes = apply_filters('arlima_article_includes', array(dirname(__FILE__).'/count-down.php'));
-        sort($file_includes);
+        $file_includes = apply_filters('arlima_article_includes', array(__('Count Down','arlima') => dirname(__FILE__).'/count-down.php'));
+        ksort($file_includes);
         $arlima_file_include = new Arlima_FileInclude();
         ?>
         <div id="arlima-article-file-includes" class="arlima-postbox">


### PR DESCRIPTION
Here's an updated suggestion on how to support this:

https://github.com/aaslun/Arlima/commit/24ac91b0cd32ae862c7df01c7644f5415bcf4ac3

The custom label has to be assigned somehow when the file include is registered with Arlima, and in an attempt to avoid an implicit solution (using the arlima_file_args) I propose using array keys for the custom labels in the arlima_article_includes filter. Will it suffice?
