### PR TITLE
Support for content not in "wp-content"

### DIFF
--- a/classes/TemplatePathResolver.php
+++ b/classes/TemplatePathResolver.php
@@ -78,10 +78,7 @@ class Arlima_TemplatePathResolver
      */
     public function fileToUrl($template_file)
     {
-        $content_dir = sprintf('%swp-content%s', DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR);
-        $parts = explode($content_dir, $template_file);
-        $parts = array_splice($parts, 1, 1);
-        $tmpl_url = WP_CONTENT_URL . '/' . current($parts);
+        $tmpl_url = WP_CONTENT_URL . '/' . str_replace(WP_CONTENT_DIR, '', $template_file);
         if ( DIRECTORY_SEPARATOR != '/' ) {
             $tmpl_url = str_replace(DIRECTORY_SEPARATOR, '/', $tmpl_url);
         }


### PR DESCRIPTION
Since WordPress supports moving the content directory to another location it's not guaranteed to have "wp-content" in its path. For example the Bedrock from Roots does this. 

This fix uses the WP_CONTENT_DIR instead of hard coded "wp-content". 
