### PR TITLE
Future posts in list preview

### DIFF
--- a/classes/AbstractListRenderingManager.php
+++ b/classes/AbstractListRenderingManager.php
@@ -141,7 +141,7 @@ abstract class Arlima_AbstractListRenderingManager
         list($post, $article_data, $is_empty) = $this->setup($article_data);
 
         // Future article
-        if ( !empty($article_data['published']) && $article_data['published'] > Arlima_Utils::timeStamp() && apply_filters('arlima_omit_future_articles', true) ) {
+        if ( !empty($article_data['published']) && $article_data['published'] > Arlima_Utils::timeStamp() ) {
             return array($index, $this->getFutureArticleContent($article_data, $index, $post));
         }
 

--- a/classes/AbstractListRenderingManager.php
+++ b/classes/AbstractListRenderingManager.php
@@ -141,7 +141,7 @@ abstract class Arlima_AbstractListRenderingManager
         list($post, $article_data, $is_empty) = $this->setup($article_data);
 
         // Future article
-        if ( !empty($article_data['published']) && $article_data['published'] > Arlima_Utils::timeStamp() ) {
+        if ( !empty($article_data['published']) && $article_data['published'] > Arlima_Utils::timeStamp() && apply_filters('arlima_omit_future_articles', true) ) {
             return array($index, $this->getFutureArticleContent($article_data, $index, $post));
         }
 


### PR DESCRIPTION
This filter provides the option of including future posts in arlima lists.
We would like to use this with a bit of css to provide support for previewing future posts in the arlima list preview.

![future posts preview](https://cloud.githubusercontent.com/assets/555273/5676922/b7a59b00-97de-11e4-8cba-d35cfb2e5dd2.png)
