### PR TITLE
Improved validation in arlima_get_list()

### DIFF
--- a/arlima.php
+++ b/arlima.php
@@ -180,7 +180,7 @@ function arlima_get_list($list_only = true) {
     static $current_arlima_list = null;
     $list_is_scheduled = false;
 
-    if( $current_arlima_list != null ) {
+    if( $current_arlima_list != null && is_object($current_arlima_list['list']) ) {
         $alv = $current_arlima_list['list']->getVersion();
         $list_is_scheduled = $alv['status'] == Arlima_List::STATUS_SCHEDULED;
     }


### PR DESCRIPTION
Sorry for this PR, but $current_arlima_list['list']->getVersion() sometimes causes fatal errors for us.
This PR should not impact any other implementation as it is just an additional is_object() check in the if-statement.

Reason: It seems that in some of our page rendering contexts, the static $current_arlima_list has a list and a status that is null. I'm guessing this has to do with how our theme implementation and Arlima plays together since this is not a known issue you are experiencing?
I'm not yet sure why or where this method call is even done at these times, but it seems to be connected with some filter or action inside or near the_content since the page rendering breaks right after the_title on any WP page. Anyway, I tried to trace down the method call to avoid this situation in the first place but it seems that I need to do some more debugging and testing.